### PR TITLE
Resume Update

### DIFF
--- a/src/globalsearch/CMakeLists.txt
+++ b/src/globalsearch/CMakeLists.txt
@@ -18,6 +18,7 @@ set( globalsearch_SRCS
      queueinterface.cpp
      queueinterfaces/local.cpp
      queueinterfaces/localdialog.cpp
+     fileutils.cpp
 )
 
 if (ENABLE_SSH)

--- a/src/globalsearch/fileutils.cpp
+++ b/src/globalsearch/fileutils.cpp
@@ -1,0 +1,40 @@
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QFileInfoList>
+
+#include "fileutils.h"
+
+// Obtained from:
+// http://john.nachtimwald.com/2010/06/08/qt-remove-directory-and-its-contents/
+// on 04/14/2015
+
+/*!
+   Delete a directory along with all of its contents.
+
+   \param dirName Path of directory to remove.
+   \return true on success; false on error.
+*/
+bool FileUtils::removeDir(const QString &dirName)
+{
+    bool result = true;
+    QDir dir(dirName);
+
+    if (dir.exists(dirName)) {
+        Q_FOREACH(QFileInfo info, dir.entryInfoList(QDir::NoDotAndDotDot | QDir::System | QDir::Hidden  | QDir::AllDirs | QDir::Files, QDir::DirsFirst)) {
+            if (info.isDir()) {
+                result = removeDir(info.absoluteFilePath());
+            }
+            else {
+                result = QFile::remove(info.absoluteFilePath());
+            }
+
+            if (!result) {
+                return result;
+            }
+        }
+        result = dir.rmdir(dirName);
+    }
+
+    return result;
+}

--- a/src/globalsearch/fileutils.h
+++ b/src/globalsearch/fileutils.h
@@ -1,0 +1,16 @@
+#ifndef FILEUTILS_H
+#define FILEUTILS_H
+
+#include <QString>
+
+// Obtained from:
+// http://john.nachtimwald.com/2010/06/08/qt-remove-directory-and-its-contents/
+// on 04/14/2015
+
+class FileUtils
+{
+public:
+    static bool removeDir(const QString &dirName);
+};
+
+#endif // FILEUTILS_H

--- a/src/globalsearch/structure.cpp
+++ b/src/globalsearch/structure.cpp
@@ -15,6 +15,7 @@
 
 #include <globalsearch/structure.h>
 #include <globalsearch/macros.h>
+#include <globalsearch/obeigenconv.h>
 
 #include <avogadro/primitive.h>
 #include <avogadro/molecule.h>
@@ -237,8 +238,9 @@ namespace GlobalSearch {
   void Structure::writeStructureSettings(const QString &filename)
   {
     SETTINGS(filename);
-    const int VERSION = 2;
+    const int VERSION = 3;
     settings->beginGroup("structure");
+    settings->setValue("saveSuccessful", false);
     settings->setValue("version",     VERSION);
     settings->setValue("generation", getGeneration());
     settings->setValue("id", getIDNumber());
@@ -252,6 +254,10 @@ namespace GlobalSearch {
     settings->setValue("failCount", getFailCount());
     settings->setValue("startTime", getOptTimerStart().toString());
     settings->setValue("endTime", getOptTimerEnd().toString());
+
+    // This will write the current enthalpy, energy, cell information, atom
+    // types, and atom positions for a structure
+    writeCurrentStructureInfo(filename);
 
     // History
     settings->beginGroup("history");
@@ -319,11 +325,14 @@ namespace GlobalSearch {
     settings->endArray();
 
     settings->endGroup(); // history
+    settings->setValue("saveSuccessful", true);
     settings->endGroup(); // structure
+
     DESTROY_SETTINGS(filename);
   }
 
-  void Structure::readStructureSettings(const QString &filename)
+  void Structure::readStructureSettings(const QString &filename,
+                                        const bool readCurrentInfo)
   {
     SETTINGS(filename);
     settings->beginGroup("structure");
@@ -342,6 +351,10 @@ namespace GlobalSearch {
 
       setOptTimerStart( QDateTime::fromString(settings->value("startTime", "").toString()));
       setOptTimerEnd(   QDateTime::fromString(settings->value("endTime",   "").toString()));
+
+    // This will read the current enthalpy, energy, cell information, atom
+    // types, and atom positions for the structure.
+    if (readCurrentInfo) readCurrentStructureInfo(filename);
 
     // History
     settings->beginGroup("history");
@@ -438,9 +451,126 @@ namespace GlobalSearch {
     case 1: // Histories added. Nothing to do, structures loaded will
             // have empty histories
     case 2:
+    case 3:
     default:
       break;
     }
+  }
+
+  void Structure::writeCurrentStructureInfo(const QString &filename)
+  {
+    SETTINGS(filename);
+    // const int VERSION = 1;
+    settings->beginGroup("structure/current");
+    settings->setValue("enthalpy", this->getEnthalpy());
+    settings->setValue("energy",   this->getEnergy());
+    settings->setValue("PV",       this->getPV());
+
+    // Atomic numbers
+    settings->beginWriteArray("atomicNums");
+    for (size_t i = 0; i < numAtoms(); i++) {
+      settings->setArrayIndex(i);
+      settings->setValue("value", QString::number(atom(i)->atomicNumber()));
+    }
+    settings->endArray();
+
+    // Cartesian coords
+    Vector3d cartCoords;
+    settings->beginWriteArray("coords");
+    for (size_t i = 0; i < numAtoms(); i++) {
+      cartCoords = *(atom(i)->pos());
+      settings->setArrayIndex(i);
+      settings->setValue("x", QString::number(cartCoords[0]));
+      settings->setValue("y", QString::number(cartCoords[1]));
+      settings->setValue("z", QString::number(cartCoords[2]));
+    }
+    settings->endArray();
+
+    // Check to see if cell info exists before saving it...
+    // This is important for non-periodic structures
+    OpenBabel::OBMol obmol = OBMol();
+    if (obmol.HasData(OBGenericDataType::UnitCell)) {
+      // Cell info
+      settings->setValue("hasCellInfo", true);
+      matrix3x3 obcell = OBUnitCell()->GetCellMatrix();
+      settings->beginGroup("cell");
+      settings->setValue("00", (obcell.Get(0,0)));
+      settings->setValue("01", (obcell.Get(0,1)));
+      settings->setValue("02", (obcell.Get(0,2)));
+      settings->setValue("10", (obcell.Get(1,0)));
+      settings->setValue("11", (obcell.Get(1,1)));
+      settings->setValue("12", (obcell.Get(1,2)));
+      settings->setValue("20", (obcell.Get(2,0)));
+      settings->setValue("21", (obcell.Get(2,1)));
+      settings->setValue("22", (obcell.Get(2,2)));
+      settings->endGroup(); // cell
+    }
+    settings->endGroup(); // structure/current
+    DESTROY_SETTINGS(filename);
+  }
+
+  void Structure::readCurrentStructureInfo(const QString &filename)
+  {
+    SETTINGS(filename);
+    settings->beginGroup("structure/current");
+    setEnthalpy(settings->value("enthalpy", 0).toDouble());
+    setEnergy(settings->value("energy", 0).toDouble());
+    setPV(settings->value("PV", 0).toDouble());
+
+    //  Atomic nums
+    size_t size;
+    size = settings->beginReadArray("atomicNums");
+    QList<unsigned int> atomicNums;
+    for (int i = 0; i < size; i++) {
+      settings->setArrayIndex(i);
+      atomicNums.append(settings->value("value").toUInt());
+    }
+    settings->endArray();
+
+    size = settings->beginReadArray("coords");
+    QList<Vector3d> cartCoords;
+    double x, y, z;
+    for (int i = 0; i < size; i++) {
+      settings->setArrayIndex(i);
+      x = settings->value("x").toDouble();
+      y = settings->value("y").toDouble();
+      z = settings->value("z").toDouble();
+      cartCoords.append(Eigen::Vector3d(x, y, z));
+    }
+    settings->endArray();
+
+    if (settings->value("hasCellInfo", false).toBool()) {
+      Eigen::Matrix3d cellMatrix;
+      settings->beginGroup("cell");
+      cellMatrix(0, 0) = settings->value("00").toDouble();
+      cellMatrix(0, 1) = settings->value("01").toDouble();
+      cellMatrix(0, 2) = settings->value("02").toDouble();
+      cellMatrix(1, 0) = settings->value("10").toDouble();
+      cellMatrix(1, 1) = settings->value("11").toDouble();
+      cellMatrix(1, 2) = settings->value("12").toDouble();
+      cellMatrix(2, 0) = settings->value("20").toDouble();
+      cellMatrix(2, 1) = settings->value("21").toDouble();
+      cellMatrix(2, 2) = settings->value("22").toDouble();
+      settings->endGroup();
+
+      // Set the cell info
+      OpenBabel::OBUnitCell *obcell = OBUnitCell();
+      obcell->SetData(Eigen2OB(cellMatrix));
+      setOBUnitCell(obcell);
+    }
+
+    // Just in case there were atoms set elsewhere for some reason...
+    QList<Atom*> atomList = atoms();
+    for (size_t i = 0; i < atomList.size(); i++)
+      this->removeAtom(atomList.at(i));
+
+    // Now let's add in the atoms...
+    for (size_t i = 0; i < atomicNums.size(); i++) {
+      Atom* newAtom = this->addAtom();
+      newAtom->setAtomicNumber(atomicNums.at(i));
+      newAtom->setPos(cartCoords.at(i));
+    }
+    settings->endGroup();
   }
 
   void Structure::structureChanged()

--- a/src/globalsearch/structure.h
+++ b/src/globalsearch/structure.h
@@ -752,11 +752,14 @@ namespace GlobalSearch {
      * If reimplementing this in a derived class, call
      * readStructureSettings(filename) to read inherited data.
      * @param filename Filename to read data from.
+     * @param readCurrentInfo Update the current info of the structure?
+     *
      * @sa readStructureSettings
      * @sa writeSettings
      */
-    virtual void readSettings(const QString &filename) {
-      readStructureSettings(filename);};
+    virtual void readSettings(const QString &filename,
+                              const bool readCurrentInfo = false) {
+      readStructureSettings(filename, readCurrentInfo);};
 
     /**
      * Update the coordinates, enthalpy and/or energy, and optionally
@@ -1060,10 +1063,30 @@ namespace GlobalSearch {
     /**
      * Read data concerning the Structure class from a file.
      * @param filename Filename to read data from.
+     * @param readCurrentInfo Update the current info of the structure?
      * @sa writeSettings
      * @sa readSettings
      */
-    void readStructureSettings(const QString &filename);
+    void readStructureSettings(const QString &filename,
+                               const bool readCurrentInfo = false);
+
+    /**
+     * Write current data for a structure to structure.state.
+     * Data includes enthalpy, energy, cell vectors, and atom info
+     * @param filename Filename to write data to.
+     * @sa writeStructureSettings
+     * @sa readStructureSettings
+     */
+    void writeCurrentStructureInfo(const QString &filename);
+
+    /**
+     * Read current data concerning a structure from structure.state.
+     * Data includes enthalpy, energy, cell vectors, and atom info
+     * @param filename Filename to read data from.
+     * @sa writeSettings
+     * @sa readSettings
+     */
+    void readCurrentStructureInfo(const QString &filename);
 
   protected:
     // skip Doxygen parsing

--- a/src/xtalopt/ui/tab_progress.cpp
+++ b/src/xtalopt/ui/tab_progress.cpp
@@ -19,6 +19,7 @@
 #include <globalsearch/optimizer.h>
 #include <globalsearch/ui/abstracttab.h>
 #include <globalsearch/optbase.h>
+#include <globalsearch/fileutils.h>
 
 #include <xtalopt/xtalopt.h>
 #include <xtalopt/ui/dialog.h>
@@ -857,65 +858,12 @@ namespace XtalOpt {
       QDir contDir(filePath+"/ranked/CONTCAR");
       QDir gotDir(filePath+"/ranked/GOT");
 
-   if(dir.exists()) {
-       if(cifDir.exists()) {
-            Q_FOREACH(QFileInfo info, cifDir.entryInfoList(QDir::NoDotAndDotDot | QDir::System | QDir::Hidden  | QDir::AllDirs | QDir::Files, QDir::DirsFirst)) {
-                if (info.isDir()) {
-                    cifDir.remove(info.absoluteFilePath());
-                }
-                else {
-                    QFile::remove(info.absoluteFilePath());
-                }
-            }
-            cifDir.rmdir(".");
-        }
-        if(gotDir.exists()) {
-            Q_FOREACH(QFileInfo info, gotDir.entryInfoList(QDir::NoDotAndDotDot | QDir::System | QDir::Hidden  | QDir::AllDirs | QDir::Files, QDir::DirsFirst)) {
-                if (info.isDir()) {
-                    gotDir.remove(info.absoluteFilePath());
-                }
-                else {
-                    QFile::remove(info.absoluteFilePath());
-                }
-            }
-            gotDir.rmdir(".");
-        }
-        if(contDir.exists()) {
-            Q_FOREACH(QFileInfo info, contDir.entryInfoList(QDir::NoDotAndDotDot | QDir::System | QDir::Hidden  | QDir::AllDirs | QDir::Files, QDir::DirsFirst)) {
-                if (info.isDir()) {
-                    contDir.remove(info.absoluteFilePath());
-                }
-                else {
-                    QFile::remove(info.absoluteFilePath());
-                }
-            }
-            contDir.rmdir(".");
-        }
-        Q_FOREACH(QFileInfo info, dir.entryInfoList(QDir::NoDotAndDotDot | QDir::System | QDir::Hidden  | QDir::AllDirs | QDir::Files, QDir::DirsFirst)) {
-            if (info.isDir()) {
-                dir.remove(info.absoluteFilePath());
-            }
-            else {
-                QFile::remove(info.absoluteFilePath());
-            }
-        }
-        dir.rmdir(".");
-        dir.mkpath(".");
-        cifDir.mkpath(".");
-        if (opti->getIDString() == "VASP") {
-            contDir.mkpath(".");
-        } else if (opti->getIDString() == "GULP") {
-            gotDir.mkpath(".");
-        }
-    } else {
-        dir.mkpath(".");
-        cifDir.mkpath(".");
-        if (opti->getIDString() == "VASP") {
-            contDir.mkpath(".");
-        } else if (opti->getIDString() == "GULP") {
-            gotDir.mkpath(".");
-        }
-    }
+   if(dir.exists()) FileUtils::removeDir(filePath+"/ranked");
+   dir.mkpath(".");
+   cifDir.mkpath(".");
+   if (opti->getIDString() == "VASP") contDir.mkpath(".");
+   else if (opti->getIDString() == "GULP") gotDir.mkpath(".");
+
    int gen, id;
    QString space, status, pathName, gen_s, id_s, enthalpy;
    QFile results (filePath+"/results.txt");

--- a/src/xtalopt/xtalopt.cpp
+++ b/src/xtalopt/xtalopt.cpp
@@ -1492,6 +1492,16 @@ namespace XtalOpt {
     // scope, but it isn't changing it here. Caching issue maybe?
     m_dialog->readSettings(filename);
 
+#ifdef ENABLE_SSH
+    // Create the SSHManager if running remotely
+    if (qobject_cast<RemoteQueueInterface*>(m_queueInterface) != 0) {
+      if (!this->createSSHConnections()) {
+        error(tr("Could not create ssh connections."));
+        return false;
+      }
+    }
+#endif // ENABLE_SSH
+
     debug(tr("Resuming XtalOpt session in '%1' (%2) readOnly = %3")
           .arg(filename)
           .arg((m_optimizer) ? m_optimizer->getIDString()
@@ -1663,19 +1673,6 @@ namespace XtalOpt {
       readOnly = !resume;
       qDebug() << "Read only? " << readOnly;
     }
-
-    #ifdef ENABLE_SSH
-        // Create the SSHManager if running remotely
-    if (!readOnly) {
-        if (qobject_cast<RemoteQueueInterface*>(m_queueInterface) != 0) {
-            if (!this->createSSHConnections()) {
-                error(tr("Could not create ssh connections."));
-            return false;
-            }
-        }
-    }
-    #endif // ENABLE_SSH
-
 
     return true;
   }


### PR DESCRIPTION
XtalOpt now checks to see if xtalopt data is already saved at the local path. If it is, then it will notify the user and ask if he or she wishes to overwrite it. A couple of extra functions that write and read current structure info were added as well. This speeds up XtalOpt loads and fixes the problem of freezing when reading output files that were not copied over correctly. Finally, a short cpp file called fileutils was added to globalsearch. It contains a function that removes directories recurisvely.

Also fixed the SSH issue.
