### PR TITLE
Uses 'getSaveFileName()' instead of 'getOpenFileName()' for saving th…

### DIFF
--- a/src/globalsearch/ui/abstractedittab.cpp
+++ b/src/globalsearch/ui/abstractedittab.cpp
@@ -449,7 +449,7 @@ namespace GlobalSearch {
     SETTINGS("");
     QString oldFilename = settings->value(m_opt->getIDString().toLower() +
                                        "/edit/schemePath/", "").toString();
-    QString filename = QFileDialog::getOpenFileName(NULL,
+    QString filename = QFileDialog::getSaveFileName(NULL,
                             tr("Save Optimization Scheme as..."),
                             oldFilename, "*.scheme;;*.state;;*.*");
 


### PR DESCRIPTION
…e scheme. This fixes a bug where windows didn't let you save it if the file didn't already exist...
